### PR TITLE
ICS: Add p5 and p5wifi

### DIFF
--- a/ics.xml
+++ b/ics.xml
@@ -35,6 +35,10 @@
   <project name="CyanogenMod/android_device_samsung_p4" path="device/samsung/p4" revision="ics" />
   <project name="CyanogenMod/android_device_samsung_p3" path="device/samsung/p3" revision="ics" />
 
+  <project name="CyanogenMod/android_device_samsung_p5-common" path="device/samsung/p5-common" revision="ics" />
+  <project name="CyanogenMod/android_device_samsung_p5wifi" path="device/samsung/p5wifi" revision="ics" />
+  <project name="CyanogenMod/android_device_samsung_p5" path="device/samsung/p5" revision="ics" />
+
   <project name="CyanogenMod/android_device_samsung_p1-common" path="device/samsung/p1-common" revision="ics" />
   <project name="CyanogenMod/android_device_samsung_p1" path="device/samsung/p1" revision="ics" />
   <project name="CyanogenMod/android_device_samsung_p1c" path="device/samsung/p1c" revision="ics" />


### PR DESCRIPTION
Adds p5 and p5wifi (Tegra based Samsung Galaxy 8.9 tabs)

These builds are "spinoffs" from pershoots 10.1 builds and uses an almost identical kernel so for the same reason kernels are prebuilt. (See discussion here: https://github.com/CyanogenMod/hudson/pull/20)
