### PR TITLE
fix archiving of zips due to new naming

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -122,7 +122,7 @@ check_result "lunch failed."
 # save manifest used for build (saving revisions as current HEAD)
 repo manifest -o $WORKSPACE/archive/manifest.xml -r
 
-rm -f $OUT/update*.zip*
+rm -f $OUT/cm-*.zip*
 
 UNAME=$(uname)
 
@@ -175,7 +175,8 @@ make $CLEAN_TYPE
 mka bacon recoveryzip recoveryimage checkapi
 check_result "Build failed."
 
-cp $OUT/update*.zip* $WORKSPACE/archive
+cp $OUT/cm-*.zip* $WORKSPACE/archive
+
 if [ -f $OUT/utilties/update.zip ]
 then
   cp $OUT/utilties/update.zip $WORKSPACE/archive/recovery.zip
@@ -186,7 +187,7 @@ then
 fi
 
 # archive the build.prop as well
-ZIP=$(ls $WORKSPACE/archive/update*.zip)
+ZIP=$(ls $WORKSPACE/archive/cm-*.zip)
 unzip -c $ZIP system/build.prop > $WORKSPACE/archive/build.prop
 
 # CORE: save manifest used for build (saving revisions as current HEAD)


### PR DESCRIPTION
Package complete: /home/jenkins/android/workspace/android/ics/out/target/product/tenderloin/cm-9-20120608-NIGHTLY-tenderloin.zip
aad28a512f07317d707225831e1a83a6  cm-9-20120608-NIGHTLY-tenderloin.zip
cp: cannot stat `/home/jenkins/android/workspace/android/ics/out/target/product/tenderloin/update_.zip_': No such file or directory
ls: cannot access /var/lib/jenkins/android/workspace/android/archive/update*.zip: No such file or directory
unzip:  cannot find or open system/build.prop, system/build.prop.zip or system/build.prop.ZIP.
