### PR TITLE
bump ccache size to 200G

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -164,7 +164,7 @@ then
   fi
 fi
 
-if [ ! "$(ccache -s|grep -E 'max cache size'|awk '{print $4}')" = "50.0" ]
+if [ ! "$(ccache -s|grep -E 'max cache size'|awk '{print $4}')" = "200.0" ]
 then
   ccache -M 200G
 fi


### PR DESCRIPTION
50G is kinda low when loads of targets are built daily
