### PR TITLE
Switch tuna kernel to new jellybean branch

### DIFF
--- a/jellybean.xml
+++ b/jellybean.xml
@@ -16,7 +16,7 @@
   <project name="TheMuppets/proprietary_vendor_sony" path="vendor/sony" revision="jellybean" />
   <project name="TheMuppets/proprietary_vendor_widevine" path="vendor/widevine" revision="jellybean" />
   <project name="CyanogenMod/android_device_samsung_maguro" path="device/samsung/maguro" remote="github" revision="jellybean" />
-  <project name="CyanogenMod/android_kernel_samsung_tuna" path="kernel/samsung/tuna" remote="github" revision="jb" />
+  <project name="CyanogenMod/android_kernel_samsung_tuna" path="kernel/samsung/tuna" remote="github" revision="jellybean" />
   <project name="CyanogenMod/android_device_samsung_tuna" path="device/samsung/tuna" remote="github" revision="jellybean" />
   <project name="CyanogenMod/android_device_samsung_toro" path="device/samsung/toro" remote="github" revision="jellybean" />
   <project name="CyanogenMod/android_device_samsung_torospr" path="device/samsung/torospr" remote="github" revision="jellybean" />


### PR DESCRIPTION
The jellybean branch switches back to the 4.1.2 kernel
source and includes CM specific changes from there.

There are reported issues with the kernel in the jb branch
so this goes back to basics and patches to this branch will
be examined more critically.

You can see the similar review in the device configurations:
http://review.cyanogenmod.org/#/c/26186/
http://review.cyanogenmod.org/#/c/26187/
http://review.cyanogenmod.org/#/c/26188/
