### PR TITLE
Add pyramid to daily build

### DIFF
--- a/cm-daily-build-targets
+++ b/cm-daily-build-targets
@@ -56,6 +56,7 @@ cm_p920-userdebug jellybean
 cm_p930-userdebug jellybean
 cm_p970-userdebug jellybean
 cm_p990-userdebug jellybean
+cm_pyramid-userdebug jellybean
 cm_quincyatt-userdebug jellybean
 cm_quincytmo-userdebug jellybean
 cm_ruby-userdebug jellybean


### PR DESCRIPTION
Might as well add pyramid too, it's in the same state as ruby. Doubleshot and Holiday to follow in the next few weeks.
