### PR TITLE
cm-daily: add p4wifi, p4vzw, p4tmo, p4 and p3 for cm-10.1

### DIFF
--- a/cm-daily-build-targets
+++ b/cm-daily-build-targets
@@ -44,12 +44,17 @@ cm_p1l-userdebug jellybean
 cm_p1n-userdebug jellybean
 cm_p1-userdebug jellybean
 cm_p3-userdebug jellybean
+cm_p3-userdebug cm-10.1
 cm_p3100-userdebug cm-10.1
 cm_p3110-userdebug cm-10.1
 cm_p4-userdebug jellybean
+cm_p4-userdebug cm-10.1
 cm_p4tmo-userdebug jellybean
+cm_p4tmo-userdebug cm-10.1
 cm_p4vzw-userdebug jellybean
+cm_p4vzw-userdebug cm-10.1
 cm_p4wifi-userdebug jellybean
+cm_p4wifi-userdebug cm-10.1
 cm_p5100-userdebug cm-10.1
 cm_p5110-userdebug cm-10.1
 cm_p720-userdebug jellybean


### PR DESCRIPTION
This is to activate nightly builds on p4wifi, p4vzw, p4tmo, p4 and p3 for cm-10.1.
