### PR TITLE
cm-daily: switch wingray and everest to cm-10.1

### DIFF
--- a/cm-daily-build-targets
+++ b/cm-daily-build-targets
@@ -14,7 +14,7 @@ cm_d2vzw-userdebug cm-10.1
 cm_encore-userdebug jellybean
 cm_endeavoru-userdebug jellybean
 cm_epicmtd-userdebug jellybean
-cm_everest-userdebug jellybean
+cm_everest-userdebug cm-10.1
 cm_evita-userdebug jellybean
 cm_fascinatemtd-userdebug cm-10.1
 cm_galaxysbmtd-userdebug cm-10.1
@@ -76,4 +76,4 @@ cm_toro-userdebug cm-10.1
 cm_urushi-userdebug jellybean
 cm_vibrantmtd-userdebug cm-10.1
 cm_ville-userdebug jellybean
-cm_wingray-userdebug jellybean
+cm_wingray-userdebug cm-10.1


### PR DESCRIPTION
Build CM10.1 for wingray (WiFi Xoom) and everest (UMTS Xoom).
