### PR TITLE
cm-daily: switch stingray to cm-10.1

### DIFF
--- a/cm-daily-build-targets
+++ b/cm-daily-build-targets
@@ -63,7 +63,7 @@ cm_ruby-userdebug jellybean
 cm_satsuma-userdebug jellybean
 cm_skyrocket-userdebug jellybean
 cm_smultron-userdebug jellybean
-cm_stingray-userdebug jellybean
+cm_stingray-userdebug cm-10.1
 cm_su640-userdebug jellybean
 cm_t769-userdebug jellybean
 cm_tf101-userdebug jellybean


### PR DESCRIPTION
Build CM10.1 for stingray (VZW Xoom 4G).
