### PR TITLE
Added missing cm-10.1 prep script

### DIFF
--- a/cm-10.1-setup.sh
+++ b/cm-10.1-setup.sh
@@ -1,0 +1,1 @@
+vendor/cm/get-prebuilts


### PR DESCRIPTION
The terminal emulator has been broken in cm-10.1 builds from jenkins for a while, when I built it myself I noticed it worked correctly, I traced the issue to the fact that there was no cm-10.1-setup.sh script file which means that the get-prebuilts script was never run by jenkins on cm-10.1 based builds and as a result the shared libraries are not downloaded, this patch should fix the issue.
