### PR TITLE
Bump HTC MSM 8960 devices to CM-10.1

### DIFF
--- a/cm-build-targets
+++ b/cm-build-targets
@@ -39,7 +39,7 @@ cm_endeavoru-userdebug jellybean W
 cm_epicmtd-userdebug jellybean W
 cyanogen_espresso-eng gingerbread M
 cm_everest-userdebug cm-10.1
-cm_evita-userdebug jellybean W
+cm_evita-userdebug cm-10.1
 cm_fascinatemtd-userdebug cm-10.1
 cm_galaxysbmtd-userdebug cm-10.1
 cm_galaxysmtd-userdebug cm-10.1
@@ -59,7 +59,7 @@ cm_i9100g-userdebug cm-10.1
 cm_i9300-userdebug cm-10.1
 cyanogen_inc-eng gingerbread M
 cm_iyokan-userdebug jellybean W
-cm_jewel-userdebug jellybean W
+cm_jewel-userdebug cm-10.1
 cm_l900-userdebug cm-10.1
 cyanogen_jordan-eng gingerbread M
 cyanogen_jordan_plus-eng gingerbread M
@@ -143,7 +143,7 @@ cm_urushi-userdebug jellybean W
 cyanogen_v9-eng gingerbread M
 cyanogen_vega-eng gingerbread M
 cm_vibrantmtd-userdebug cm-10.1
-cm_ville-userdebug jellybean W
+cm_ville-userdebug cm-10.1
 cyanogen_vision-eng gingerbread M
 cyanogen_vivo-eng gingerbread M
 cyanogen_vivow-eng gingerbread M


### PR DESCRIPTION
1080p video recording is still broken, but everything else works.
