### PR TITLE
Setup nightlies for the Kindle Fires

### DIFF
--- a/cm-10.1.xml
+++ b/cm-10.1.xml
@@ -2,6 +2,7 @@
 <manifest>
   <project name="TheMuppets/proprietary_vendor_acer" path="vendor/acer" revision="cm-10.1" />
   <project name="TheMuppets/proprietary_vendor_akm" path="vendor/akm" revision="cm-10.1" />
+  <project name="TheMuppets/proprietary_vendor_amazon" path="vendor/amazon" revision="cm-10.1" />
   <project name="TheMuppets/proprietary_vendor_asus" path="vendor/asus" revision="cm-10.1" />
   <project name="TheMuppets/proprietary_vendor_audience" path="vendor/audience" revision="cm-10.1" />
   <project name="TheMuppets/proprietary_vendor_bn" path="vendor/bn" revision="cm-10.1" />

--- a/cm-build-targets
+++ b/cm-build-targets
@@ -81,6 +81,8 @@ cm_n8013-userdebug cm-10.1
 cm_nozomi-userdebug ics W
 cm_odroidu2-userdebug cm-10.1
 cyanogen_olympus-eng gingerbread M
+cm_otter cm-10.1
+cm_otter2 cm-10.1
 cm_p1c-userdebug jellybean W
 cm_p1l-userdebug jellybean W
 cm_p1n-userdebug jellybean W


### PR DESCRIPTION
Added both cm_otter and cm_otter2 to cm-build-targets on cm-10.1 and vendor/amazon to the proprietaries list.
