### PR TITLE
add expressatt to cm-10.2 nightly build targets

### DIFF
--- a/cm-build-targets
+++ b/cm-build-targets
@@ -32,6 +32,7 @@ cm_enrc2b-userdebug cm-10.1
 cm_epicmtd-userdebug cm-10.1
 cm_everest-userdebug cm-10.1
 cm_evita-userdebug cm-10.2
+cm_expressatt-userdebug cm-10.2
 cm_fascinatemtd-userdebug cm-10.1
 cm_find5-userdebug cm-10.1
 cm_fireball-userdebug cm-10.1


### PR DESCRIPTION
Needs device tree to be forked: https://github.com/jt1134/android_device_samsung_expressatt

All the other dependencies in the d2 repositories have already been merged.
