### PR TITLE
Switch fireball to cm-10.2

### DIFF
--- a/cm-build-targets
+++ b/cm-build-targets
@@ -36,7 +36,7 @@ cm_everest-userdebug cm-10.1 W
 cm_evita-userdebug cm-10.2
 cm_fascinatemtd-userdebug cm-10.1 W
 cm_find5-userdebug cm-10.1 W
-cm_fireball-userdebug cm-10.1 W
+cm_fireball-userdebug cm-10.2
 cm_flo-userdebug cm-10.2
 cm_galaxysbmtd-userdebug cm-10.2
 cm_galaxysmtd-userdebug cm-10.2


### PR DESCRIPTION
The cm-10.2 branch now has fewer known issues than cm-10.1 on fireball -- most notably camera and camcorder are working.  The most outstanding issue that affects both cm-10.1 and cm-10.2 is some devices have flickering displays after display-on when device has been asleep for a while.  Otherwise, the remaining issues (volume and audio routing for camcorder) are manageable and being worked on.
