### PR TITLE
Add superior (i9260) to cm-10.2

### DIFF
--- a/cm-build-targets
+++ b/cm-build-targets
@@ -131,6 +131,7 @@ cm_spyder-userdebug cm-10.2
 cm_steelhead-userdebug cm-10.1 W
 cm_stingray-userdebug cm-10.1 W
 cm_su640-userdebug cm-10.1 W
+cm_superior-userdebug cm-10.2
 cm_t0lte-userdebug cm-10.2
 cm_t0lteatt-userdebug cm-10.2
 cm_t0ltetmo-userdebug cm-10.2


### PR DESCRIPTION
The device file is on https://github.com/ljzyal/android_device_samsung_superior
