### PR TITLE
Return evita and ville to cm-10.2

### DIFF
--- a/cm-build-targets
+++ b/cm-build-targets
@@ -35,7 +35,7 @@ cm_endeavoru-userdebug cm-10.2
 cm_enrc2b-userdebug cm-10.2
 cm_epicmtd-userdebug cm-10.1 W
 cm_everest-userdebug cm-10.1 W
-cm_evita-userdebug cm-11.0
+cm_evita-userdebug cm-10.2
 cm_exhilarate-userdebug cm-11.0
 cm_fascinatemtd-userdebug cm-10.1 W
 cm_find5-userdebug cm-10.1 W
@@ -149,7 +149,7 @@ cm_tsubasa-userdebug cm-11.0
 cm_umts_spyder-userdebug cm-10.2
 cm_urushi-userdebug jellybean W
 cm_vibrantmtd-userdebug cm-10.1 W
-cm_ville-userdebug cm-11.0
+cm_ville-userdebug cm-10.2
 cm_vs920-userdebug cm-10.2
 cm_vs980-userdebug cm-11.0
 cm_wingray-userdebug cm-10.1 W


### PR DESCRIPTION
- The 4.4.1 merge renders these devices completely unusable as they
  continuously reboot.
