### PR TITLE
Remove xt897c from nightlies

### DIFF
--- a/cm-build-targets
+++ b/cm-build-targets
@@ -154,7 +154,6 @@ cm_vs920-userdebug cm-10.2
 cm_vs980-userdebug cm-11.0
 cm_wingray-userdebug cm-10.1 W
 cm_xt897-userdebug cm-11.0
-cm_xt897c-userdebug cm-11.0
 cm_xt907-userdebug cm-11.0
 cm_xt925-userdebug cm-11.0
 cm_xt926-userdebug cm-11.0


### PR DESCRIPTION
The xt897 and xt897c builds are now unified.
