### PR TITLE
Move Nook HD+ (ovation) and Nook HD (hummingbird) to CM-11.0

### DIFF
--- a/cm-build-targets
+++ b/cm-build-targets
@@ -49,7 +49,7 @@ cm_hallon-userdebug jellybean W
 cm_hammerhead-userdebug cm-11.0
 cm_hercules-userdebug cm-11.0
 cm_holiday-userdebug jellybean W
-cm_hummingbird-userdebug cm-10.2
+cm_hummingbird-userdebug cm-11.0
 cm_i605-userdebug cm-11.0
 cm_i777-userdebug cm-10.2
 cm_i9100-userdebug cm-10.2
@@ -93,7 +93,7 @@ cm_odin-userdebug cm-11.0
 cm_odroidu2-userdebug cm-10.2
 cm_otter-userdebug cm-11.0
 cm_otter2-userdebug cm-11.0
-cm_ovation-userdebug cm-10.2
+cm_ovation-userdebug cm-11.0
 cm_p1c-userdebug jellybean W
 cm_p1-userdebug cm-11.0
 cm_p3-userdebug cm-10.1 W


### PR DESCRIPTION
Checks out ok locally and positive reports from local builds from multiple users, so should be good to go.
