### PR TITLE
Added LG Optimus L3 (e400) line

### DIFF
--- a/cm-build-targets
+++ b/cm-build-targets
@@ -22,6 +22,7 @@ cm_d802-userdebug cm-11.0
 cm_deb-userdebug cm-11.0
 cm_dlx-userdebug cm-11.0
 cm_dogo-userdebug cm-11.0
+cm_e400-userdebug cm-10.2
 cm_e610-userdebug jellybean M
 cm_e970-userdebug cm-11.0
 cm_e973-userdebug cm-11.0


### PR DESCRIPTION
Without that line, I can't build my own CyanogenMod.
To build my fork I used "repo init -u git://[...] -b jellybean" and I think I need it to build it.
