### PR TITLE
Push d855 to cm12.1

### DIFF
--- a/cm-build-targets
+++ b/cm-build-targets
@@ -11,6 +11,7 @@ cm_castor_windy-userdebug cm-12.1
 cm_condor-userdebug cm-12.1
 cm_deb-userdebug cm-12.1
 cm_dlx-userdebug cm-12.1
+cm_d855-userdebug cm-12.1
 cm_e975-userdebug cm-12.1
 cm_e980-userdebug cm-12.1
 cm_evita-userdebug cm-12.1
@@ -92,7 +93,6 @@ cm_d802-userdebug cm-12.0
 cm_d850-userdebug cm-12.0
 cm_d851-userdebug cm-12.0
 cm_d852-userdebug cm-12.0
-cm_d855-userdebug cm-12.0
 cm_e970-userdebug cm-12.0
 cm_find5-userdebug cm-12.0
 cm_flounder-userdebug cm-12.0


### PR DESCRIPTION
My privat cm12.1 builds for a d855 are running as good as the cm12.0 nightlies. Are there any concerns against pushing it to cm12.1?