### PR TITLE
cm-build-targets: enabled cm-13.0 for shamu

### DIFF
--- a/cm-build-targets
+++ b/cm-build-targets
@@ -18,6 +18,7 @@ hammerhead userdebug cm-13.0
 hammerheadcaf userdebug cm-13.0
 m8 userdebug cm-13.0
 mondrianwifi userdebug cm-13.0
+shamu userdebug cm-13.0
 v400 userdebug cm-13.0
 v410 userdebug cm-13.0
 vs980 userdebug cm-13.0
@@ -119,7 +120,6 @@ scorpion userdebug cm-12.1
 scorpion_windy userdebug cm-12.1
 serrano3gxx userdebug cm-12.1
 serranoltexx userdebug cm-12.1
-shamu userdebug cm-12.1
 shieldtablet userdebug cm-12.1
 sirius userdebug cm-12.1
 spyder userdebug cm-12.1


### PR DESCRIPTION
Enabled CyanogenMod 13.0 branch as the default for Shamu (Nexus 6)