### PR TITLE
Add back angler (Nexus 6P) as weekly CM13 target

### DIFF
--- a/cm-build-targets
+++ b/cm-build-targets
@@ -95,6 +95,7 @@ peach userdebug cm-13.0
 
 # Weekly cm-13.0
 a5dwg userdebug cm-13.0 W
+angler userdebug cm-13.0 W
 che10 userdebug cm-13.0 W
 cherry userdebug cm-13.0 W
 crackling userdebug cm-13.0 W


### PR DESCRIPTION
Would love to test both CM13 and CM14 with new code.  Please consider this weekly build config for CM13 until CM14 is stable.